### PR TITLE
Split support for AngularJS and Angular 2+

### DIFF
--- a/docs/Installing/index.html
+++ b/docs/Installing/index.html
@@ -154,7 +154,8 @@
         <li><a href="#bower">bower</a></li>
         <li><a href="#nuget">Nuget</a></li>
         <li><a href="#rails">Rails</a></li>
-        <li><a href="#angular-wrapper">Angular Wrapper</a></li>
+        <li><a href="#angular-wrapper">AngularJS Wrapper</a></li>
+        <li><a href="#angular-2-wrapper">Angular 2+ Wrapper</a></li>
         <li><a href="#meteorjs">Meteor.js</a></li>
         <li><a href="#manual">Manual</a></li>
         <li><a href="#knockout">Knockout</a></li>
@@ -174,7 +175,8 @@
 <li><a href="#bower-">Bower</a></li>
 <li><a href="#nuget">Nuget</a></li>
 <li><a href="#rails-">Rails</a></li>
-<li><a href="#angular-wrapper">Angular</a></li>
+<li><a href="#angular-wrapper">AngularJS</a></li>
+<li><a href="#angular-2-wrapper">Angular 2+</a></li>
 <li><a href="#meteorjs">Meteor.js</a></li>
 <li><a href="#manual">Manual</a></li>
 </ul>
@@ -214,6 +216,8 @@
 <p>Need new wrapper for this version.</p>
 <h2 id="angular-wrapper">Angular Wrapper</h2>
 <p>Need new wrapper for this version.</p>
+<h2 id="angular-2-wrapper">Angular 2+ Wrapper</h2>
+<p>A wrapper component for Angular 2+ <a href="https://github.com/dgasparri/Angular-2-Eonasdan-Bootstrap-datetimepicker-Wrapper-Component">can be found here</a></p>
 <h2 id="meteorjs">Meteor.js</h2>
 <p>Need new wrapper for this version.</p>
 <h2 id="manual">Manual</h2>


### PR DESCRIPTION
Improved support for "Angular", now split between AngularJS and the completely different Angular 2+

Added a link to a full wrapper component, that can be found here https://github.com/dgasparri/Angular-2-Eonasdan-Bootstrap-datetimepicker-Wrapper-Component

The wrapper component could be as well imported into bootstrap3, but I did not know where it could be placed so I just created a different repository